### PR TITLE
refactor: inject logging into ui

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,17 +2,18 @@
 import sys
 from PySide6 import QtWidgets, QtGui
 from pathlib import Path
+import logging
 from app.core.config.settings import Settings
 from app.core.util.logging import setup_logging
 from app.ui.main_window import MainWindow
 
 def main():
-    settings = Settings.load()
     setup_logging(Path('logs'))
+    settings = Settings.load()
     app = QtWidgets.QApplication(sys.argv)
     app.setStyle("Fusion")
     app.setFont(QtGui.QFont("Segoe UI", 10))
-    win = MainWindow(settings)
+    win = MainWindow(settings, logging.getLogger(__name__))
     win.show()
     sys.exit(app.exec())
 

--- a/app/ui/class_search_dialog.py
+++ b/app/ui/class_search_dialog.py
@@ -1,8 +1,10 @@
 from PySide6 import QtWidgets, QtCore
+import logging
 
 class ClassSearchDialog(QtWidgets.QDialog):
-    def __init__(self, classes, parent=None):
+    def __init__(self, classes, parent=None, logger: logging.Logger | None = None):
         super().__init__(parent)
+        self.logger = logger or logging.getLogger(__name__)
         self.setWindowTitle('Klasse suchen')
         self.classes = list(classes)
         layout = QtWidgets.QVBoxLayout(self)

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -1,12 +1,14 @@
 # app/ui/settings_dialog.py
 from PySide6 import QtWidgets
+import logging
 from pathlib import Path
 from ..core.config.settings import Settings
 
 
 class SettingsDialog(QtWidgets.QDialog):
-    def __init__(self, settings: Settings, parent=None):
+    def __init__(self, settings: Settings, parent=None, logger: logging.Logger | None = None):
         super().__init__(parent)
+        self.logger = logger or logging.getLogger(__name__)
         self.settings = settings
         self.setWindowTitle('Einstellungen')
 

--- a/app/ui/widgets/live_view_widget.py
+++ b/app/ui/widgets/live_view_widget.py
@@ -2,12 +2,14 @@
 from pathlib import Path
 from PySide6 import QtWidgets, QtGui, QtCore
 from .overlay import Overlay
+import logging
 
 class LiveViewWidget(QtWidgets.QWidget):
     """Widget zur Anzeige des Live-Streams mit einblendbarem Overlay."""
 
-    def __init__(self, camera, fps: int = 20, parent=None):
+    def __init__(self, camera, fps: int = 20, parent=None, logger: logging.Logger | None = None):
         super().__init__(parent)
+        self.logger = logger or logging.getLogger(__name__)
         self.camera = camera
         self.label = QtWidgets.QLabel()
         self.label.setAlignment(QtCore.Qt.AlignCenter)
@@ -17,7 +19,7 @@ class LiveViewWidget(QtWidgets.QWidget):
             QtWidgets.QSizePolicy.Expanding,
         )
         self.frame_ratio = 3 / 4
-        self.overlay = Overlay()
+        self.overlay = Overlay(logger=self.logger)
         layout = QtWidgets.QStackedLayout(self)
         layout.setStackingMode(QtWidgets.QStackedLayout.StackAll)
         layout.addWidget(self.label)
@@ -83,4 +85,5 @@ class LiveViewWidget(QtWidgets.QWidget):
                 )
                 self.label.setPixmap(pix)
         except Exception as e:
+            self.logger.error("Live view update failed: %s", e)
             self.label.setText(str(e))

--- a/app/ui/widgets/overlay.py
+++ b/app/ui/widgets/overlay.py
@@ -1,13 +1,15 @@
 # app/ui/widgets/overlay.py
 from pathlib import Path
 from PySide6 import QtWidgets, QtGui, QtCore
+import logging
 
 
 class Overlay(QtWidgets.QWidget):
     """Zeigt ein optionales PNG-Bild ueber dem LiveView."""
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, logger: logging.Logger | None = None):
         super().__init__(parent)
+        self.logger = logger or logging.getLogger(__name__)
         self.pixmap = None
         self.setAttribute(QtCore.Qt.WA_TransparentForMouseEvents)
         self.setAttribute(QtCore.Qt.WA_NoSystemBackground)


### PR DESCRIPTION
## Summary
- configure logging before settings load and pass logger to main window
- inject logging into UI classes and centralize user notifications
- log live view update failures

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c2764e6dc832c842d996db89b2ff0