### PR TITLE
feat: centralize logging and notifications

### DIFF
--- a/app/core/controller.py
+++ b/app/core/controller.py
@@ -26,7 +26,7 @@ class MainController:
 
     # camera -----------------------------------------------------------------
     def _init_camera(self):
-        backend = self.settings.kamera.get("backend", "opencv")
+        backend = getattr(self.settings.kamera, "backend", "opencv")
         cam = None
         if backend == "gphoto2" and QtCore.QStandardPaths.findExecutable("gphoto2"):
             cam = GPhoto2Camera()
@@ -109,13 +109,13 @@ class MainController:
             out_dir = class_output_dir(self.settings.ausgabeBasisPfad, location, learner.klasse)
             raw_path = unique_file_path(out_dir, f"{learner.schueler_id}.jpg")
         self.camera.capture(raw_path)
-        aspect = self.settings.bild.get("seitenverhaeltnis", (3, 4))
+        aspect = getattr(self.settings.bild, "seitenverhaeltnis", (3, 4))
         process_image(
             raw_path,
             raw_path,
-            self.settings.bild["breite"],
-            self.settings.bild["hoehe"],
-            self.settings.bild["qualitaet"],
+            self.settings.bild.breite,
+            self.settings.bild.hoehe,
+            self.settings.bild.qualitaet,
             aspect,
         )
         return raw_path
@@ -147,7 +147,7 @@ class MainController:
         if files:
             from .archiver.chunk_zip import chunk_by_count
             zip_base = out_dir / f"{klasse}.zip"
-            max_count = self.settings.zip.get("maxAnzahl") or len(files)
+            max_count = getattr(self.settings.zip, "maxAnzahl", None) or len(files)
             zip_paths = chunk_by_count(files, zip_base, max_count)
         else:
             zip_paths = []

--- a/app/main.py
+++ b/app/main.py
@@ -1,27 +1,33 @@
 # app/main.py
 import sys
-from PySide6 import QtWidgets, QtGui
+import logging
 from pathlib import Path
+
+from PySide6 import QtWidgets, QtGui
+
 from app.core.config.settings import Settings
 from pydantic import ValidationError
 from app.core.util.logging import setup_logging
 from app.core.controller import MainController
 from app.ui.main_window import MainWindow
 
-def main():
+
+def main() -> int:
+    setup_logging(Path('logs'))
+    logger = logging.getLogger(__name__)
     try:
         settings = Settings.load()
     except ValidationError as e:
-        print(f"Fehler in der Konfiguration: {e}", file=sys.stderr)
+        logger.error("Fehler in der Konfiguration: %s", e)
         return 1
-    setup_logging(Path('logs'))
+
     app = QtWidgets.QApplication(sys.argv)
     app.setStyle("Fusion")
     app.setFont(QtGui.QFont("Segoe UI", 10))
     controller = MainController(settings)
-    win = MainWindow(settings, controller)
+    win = MainWindow(settings, controller, logger=logger.getChild('MainWindow'))
     win.show()
-    sys.exit(app.exec())
+    return app.exec()
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/app/ui/class_search_dialog.py
+++ b/app/ui/class_search_dialog.py
@@ -1,8 +1,10 @@
 from PySide6 import QtWidgets, QtCore
+import logging
 
 class ClassSearchDialog(QtWidgets.QDialog):
-    def __init__(self, classes, parent=None):
+    def __init__(self, classes, parent=None, logger: logging.Logger | None = None):
         super().__init__(parent)
+        self.logger = logger or logging.getLogger(type(self).__name__)
         self.setWindowTitle('Klasse suchen')
         self.classes = list(classes)
         layout = QtWidgets.QVBoxLayout(self)


### PR DESCRIPTION
## Summary
- inject and propagate logging.Logger into UI components
- replace ad-hoc message boxes with structured logging and optional dialogs
- initialize logging on startup and use attribute access for settings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c2ad68b18832c94b5aa3c50e3972d