### PR TITLE
Add PyInstaller build workflow

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -1,0 +1,34 @@
+name: Build EXE on branch creation
+
+on:
+  create:
+    branches:
+      - '*'
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+
+      - name: Build EXE
+        run: |
+          pyinstaller --onefile --windowed -n LegicCardCreator --icon=icon.ico --add-data "app\ui\widgets\control_panel.ui;app\ui\widgets" app\main.py
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: LegicCardCreator
+          path: dist/LegicCardCreator.exe

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Eine Desktop-Anwendung zur schnellen Erstellung von Portraitfotos für Klassen u
 - [▶️ Nutzung](#-nutzung)
 - [⌨️ Tastenkürzel](#-tastenkürzel)
 - [🧪 Tests](#-tests)
+- [🖥️ Windows-EXE aus GitHub Actions](#-windows-exe-aus-github-actions)
 - [📄 Lizenz](#-lizenz)
 
 ## 🚀 Features
@@ -46,6 +47,19 @@ Beim Abschluss werden alle Fotos einer Klasse automatisch zu einem ZIP-Archiv zu
 ```bash
 pytest
 ```
+
+## 🖥️ Windows-EXE aus GitHub Actions
+Ein GitHub-Workflow baut automatisch eine Windows-Exe, sobald ein neuer Branch im entfernten Repository angelegt wird.
+
+1. Erstelle lokal einen neuen Branch:
+   ```bash
+   git checkout -b mein-branch
+   git push -u origin mein-branch
+   ```
+2. Öffne auf GitHub den Tab **Actions** und wähle den Lauf **Build EXE on branch creation**.
+3. Unter **Artifacts** kannst du das Archiv **LegicCardCreator** herunterladen. Darin befindet sich die Datei `LegicCardCreator.exe` aus dem `dist/`-Ordner.
+
+Die EXE kann anschließend wie gewohnt auf Windows ausgeführt werden.
 
 ## 📄 Lizenz
 Dieses Projekt steht unter der [MIT-Lizenz](LICENSE).


### PR DESCRIPTION
## Summary
- build LegicCardCreator executable with PyInstaller whenever a new branch is created
- upload built EXE as workflow artifact
- document how to trigger the workflow and download the EXE

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a32e6ab868832c8e571ef55de26120