### PR TITLE
Configurable settings location and walk-in photo folder

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 import json
 import os
+import sys
 from typing import Tuple, Optional
 
 from pydantic import BaseModel, Field, field_validator, ConfigDict
@@ -13,7 +14,35 @@ from pydantic import BaseModel, Field, field_validator, ConfigDict
 # Storage locations
 # ---------------------------------------------------------------------------
 
-CONFIG_DIR = Path(os.getenv("APPDATA", str(Path.home()))) / "LegicCardCreator"
+def _app_base_dir() -> Path:
+    """Directory containing the running .exe (frozen build), or this file's
+    project root when running from source."""
+    if getattr(sys, 'frozen', False):
+        return Path(sys.executable).parent
+    return Path(__file__).resolve().parents[3]
+
+
+def _resolve_config_dir() -> Path:
+    """Resolve where settings.json (and related config files) live.
+
+    Priority:
+    1. LEGICCARD_CONFIG_DIR environment variable, if set.
+    2. Portable mode: a 'config' folder placed next to the .exe by the
+       operator (e.g. on a shared/USB drive so settings travel with the app).
+    3. Default: %APPDATA%\\LegicCardCreator (falls back to the home
+       directory on non-Windows platforms).
+    """
+    env_override = os.getenv("LEGICCARD_CONFIG_DIR")
+    if env_override:
+        return Path(env_override)
+    if getattr(sys, 'frozen', False):
+        portable_dir = _app_base_dir() / "config"
+        if portable_dir.is_dir():
+            return portable_dir
+    return Path(os.getenv("APPDATA", str(Path.home()))) / "LegicCardCreator"
+
+
+CONFIG_DIR = _resolve_config_dir()
 CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 CONFIG_PATH = CONFIG_DIR / "settings.json"
 
@@ -23,12 +52,18 @@ def _default_output_path() -> Path:
     return Path(os.getenv("USERPROFILE", str(Path.home()))) / "Pictures" / "LegicCardCreator"
 
 
+def _default_new_learner_path() -> Path:
+    """Return the default folder for walk-in students not on the roster."""
+    return _default_output_path() / "Neue Lernende"
+
+
 # ---------------------------------------------------------------------------
 # First-run defaults (used when settings.json does not yet exist)
 # ---------------------------------------------------------------------------
 
 DEFAULTS = {
     'ausgabeBasisPfad': str(_default_output_path()),
+    'neueLernendeBasisPfad': str(_default_new_learner_path()),
     'missedPath': str(CONFIG_DIR / 'Verpasste_Termine.xlsx'),
     'bild': {
         'breite': 1200,
@@ -140,6 +175,7 @@ class Settings(BaseModel):
     model_config = ConfigDict(validate_assignment=True)
 
     ausgabeBasisPfad: Path = Field(default_factory=_default_output_path)
+    neueLernendeBasisPfad: Path = Field(default_factory=_default_new_learner_path)
     missedPath: Path = Field(default_factory=lambda: CONFIG_DIR / 'Verpasste_Termine.xlsx')
     bild: BildSettings = Field(default_factory=BildSettings)
     overlay: OverlaySettings = Field(default_factory=OverlaySettings)
@@ -160,6 +196,7 @@ class Settings(BaseModel):
     def save(self, path: Path = CONFIG_PATH) -> None:
         data = self.model_dump()
         data['ausgabeBasisPfad'] = str(data['ausgabeBasisPfad'])
+        data['neueLernendeBasisPfad'] = str(data['neueLernendeBasisPfad'])
         data['missedPath'] = str(data['missedPath'])
         ratio = data['bild']['seitenverhaeltnis']
         data['bild']['seitenverhaeltnis'] = f"{ratio[0]}:{ratio[1]}"

--- a/app/core/controller.py
+++ b/app/core/controller.py
@@ -120,7 +120,7 @@ class MainController:
 
     def capture(self, learner: Learner, location: str) -> Path:
         if learner.is_new:
-            out_dir = new_learner_dir(self.settings.ausgabeBasisPfad, location, learner.klasse)
+            out_dir = new_learner_dir(self.settings.neueLernendeBasisPfad, location, learner.klasse)
             raw_path = unique_file_path(out_dir, f"{learner.vorname}_{learner.nachname}.jpg")
         else:
             out_dir = class_output_dir(self.settings.ausgabeBasisPfad, location, learner.klasse)

--- a/app/core/util/paths.py
+++ b/app/core/util/paths.py
@@ -30,9 +30,13 @@ def class_output_dir(base: Union[str, Path], location: str, class_name: str) -> 
 
 
 def new_learner_dir(base: Union[str, Path], location: str, class_name: str) -> Path:
-    """Return folder for additional learners."""
-    base_path = Path(base) / 'Neue Lernende'
-    return class_output_dir(base_path, location, class_name)
+    """Return folder for additional (walk-in) learners under *base*.
+
+    *base* is expected to already be the dedicated "new learners" base path
+    (``Settings.neueLernendeBasisPfad``), separate from the main class-photo
+    output path so it can be configured independently.
+    """
+    return class_output_dir(base, location, class_name)
 
 
 def unique_file_path(directory: Union[str, Path], filename: str) -> Path:

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -310,7 +310,9 @@ class MainWindow(QtWidgets.QMainWindow):
         if learner.is_new:
             # Visual distinction: blue label + tooltip explaining the save location.
             self.label_current.setStyleSheet('font-size:16px; color: #0078d4;')
-            self.label_current.setToolTip('Neue Person – wird im Ordner "Neue Lernende" gespeichert')
+            self.label_current.setToolTip(
+                f'Neue Person – wird gespeichert in: {self.settings.neueLernendeBasisPfad}'
+            )
         else:
             self.label_current.setStyleSheet('font-size:16px;')
             self.label_current.setToolTip('')

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -1,9 +1,9 @@
 # app/ui/settings_dialog.py
-from PySide6 import QtWidgets
+from PySide6 import QtWidgets, QtGui, QtCore
 from pathlib import Path
 from pydantic import ValidationError
 import logging
-from ..core.config.settings import Settings, ExcelMapping
+from ..core.config.settings import Settings, ExcelMapping, CONFIG_PATH
 
 
 class SettingsDialog(QtWidgets.QDialog):
@@ -58,6 +58,35 @@ class SettingsDialog(QtWidgets.QDialog):
         h_out.addWidget(self.btn_output)
         form.addRow('Ausgabeordner', h_out)
         self.btn_output.clicked.connect(self.choose_output)
+
+        # base folder for walk-in students not on the roster ("Neue Lernende")
+        self.new_learner_dir = str(self.settings.neueLernendeBasisPfad)
+        self.lbl_new_learner = QtWidgets.QLabel(self.new_learner_dir)
+        self.lbl_new_learner.setWordWrap(True)
+        self.btn_new_learner = QtWidgets.QPushButton('Ordner wählen...')
+        h_new = QtWidgets.QHBoxLayout()
+        h_new.addWidget(self.lbl_new_learner, stretch=1)
+        h_new.addWidget(self.btn_new_learner)
+        form.addRow('Ordner für neue Lernende', h_new)
+        self.btn_new_learner.clicked.connect(self.choose_new_learner_dir)
+
+        # settings.json location (read-only; see LEGICCARD_CONFIG_DIR / portable
+        # "config" folder next to the .exe to relocate it)
+        self.lbl_config_path = QtWidgets.QLabel(str(CONFIG_PATH))
+        self.lbl_config_path.setWordWrap(True)
+        self.lbl_config_path.setToolTip(
+            'Um diesen Speicherort zu ändern: einen Ordner namens "config" neben\n'
+            'die LegicCardCreator.exe legen (Portable-Modus), oder die\n'
+            'Umgebungsvariable LEGICCARD_CONFIG_DIR setzen.'
+        )
+        btn_open_config = QtWidgets.QPushButton('Ordner öffnen')
+        btn_open_config.clicked.connect(
+            lambda: QtGui.QDesktopServices.openUrl(QtCore.QUrl.fromLocalFile(str(CONFIG_PATH.parent)))
+        )
+        h_config = QtWidgets.QHBoxLayout()
+        h_config.addWidget(self.lbl_config_path, stretch=1)
+        h_config.addWidget(btn_open_config)
+        form.addRow('Konfigurationsdatei', h_config)
 
         # missed file path
         self.missed_path = str(self.settings.missedPath)
@@ -152,6 +181,12 @@ class SettingsDialog(QtWidgets.QDialog):
             self.output_dir = path
             self.lbl_output.setText(path)
 
+    def choose_new_learner_dir(self):
+        path = QtWidgets.QFileDialog.getExistingDirectory(self, 'Ordner wählen', self.new_learner_dir)
+        if path:
+            self.new_learner_dir = path
+            self.lbl_new_learner.setText(path)
+
     def choose_missed(self):
         path, _ = QtWidgets.QFileDialog.getSaveFileName(self, 'Datei wählen', self.missed_path, filter='Excel (*.xlsx)')
         if path:
@@ -184,6 +219,7 @@ class SettingsDialog(QtWidgets.QDialog):
         )
         self.settings.overlay.image = Path(self.overlay_path) if self.overlay_path else None
         self.settings.ausgabeBasisPfad = Path(self.output_dir)
+        self.settings.neueLernendeBasisPfad = Path(self.new_learner_dir)
         self.settings.missedPath = Path(self.missed_path)
         try:
             self.settings.save()

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -12,9 +12,11 @@ def test_class_output_dir(tmp_path):
     assert path == tmp_path / 'Standort' / 'Klasse'
 
 def test_new_learner_dir(tmp_path):
+    # new_learner_dir takes the dedicated "Neue Lernende" base path directly
+    # (Settings.neueLernendeBasisPfad), so no extra subfolder is appended here.
     path = new_learner_dir(str(tmp_path), 'Standort', 'Klasse')
     assert path.exists()
-    assert path == tmp_path / 'Neue Lernende' / 'Standort' / 'Klasse'
+    assert path == tmp_path / 'Standort' / 'Klasse'
 
 
 def test_unique_file_path(tmp_path):


### PR DESCRIPTION
## Summary
- Portable config support: settings.json now resolves from `LEGICCARD_CONFIG_DIR` env var, then a `config` folder next to the packaged .exe, then `%APPDATA%\LegicCardCreator` as before (unchanged default behavior if nothing is set up)
- New `neueLernendeBasisPfad` setting: walk-in students ("Neue Lernende") now get their own independently configurable base folder, instead of a hardcoded subfolder under the main output path
- Settings dialog: added a folder picker for the walk-in path, plus a read-only display + "open folder" button showing the current settings.json location and how to relocate it

## Test plan
- [x] `pytest` (15 passed, 10 pre-existing unrelated errors)
- [x] Verified `Settings.load()` correctly defaults the new field for existing settings.json files that predate this change
- [x] Launched app on macOS, confirmed Settings dialog imports/opens without errors